### PR TITLE
Fix error in absolute link

### DIFF
--- a/app/assets/javascripts/discourse/components/small-action.js.es6
+++ b/app/assets/javascripts/discourse/components/small-action.js.es6
@@ -3,7 +3,7 @@ import { autoUpdatingRelativeAge } from 'discourse/lib/formatter';
 export function actionDescriptionHtml(actionCode, createdAt, username) {
   const dt = new Date(createdAt);
   const when = autoUpdatingRelativeAge(dt, { format: 'medium-with-ago' });
-  const who = username ? `<a class="mention" href="/users/${username}">@${username}</a>` : "";
+  const who = username ? `<a class="mention" href="/forum/users/${username}">@${username}</a>` : "";
   return I18n.t(`action_codes.${actionCode}`, { who, when }).htmlSafe();
 }
 


### PR DESCRIPTION
I was getting SEO crawl issues from an incorrect absolute path when users were mentioned in a comment.
